### PR TITLE
chore(root): add lint and test support

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,20 @@
+import eslintPluginTs from '@typescript-eslint/eslint-plugin';
+import parser from '@typescript-eslint/parser';
+
+export default [
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': eslintPluginTs,
+    },
+    rules: {
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -7,13 +7,19 @@
     "dev:web": "pnpm --filter web dev",
     "dev:api": "pnpm --filter api dev",
     "prepare": "husky install",
-    "release": "changeset version && changeset publish"
+    "release": "changeset version && changeset publish",
+    "lint": "eslint \"packages/**/*.{ts,tsx}\"",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.0",
     "@changesets/changelog-github": "^0.4.2",
     "@commitlint/cli": "^18.0.0",
     "@commitlint/config-conventional": "^18.0.0",
-    "husky": "^8.0.3"
+    "husky": "^8.0.3",
+    "eslint": "^8.56.0",
+    "@typescript-eslint/parser": "^6.7.0",
+    "@typescript-eslint/eslint-plugin": "^6.7.0",
+    "vitest": "^1.0.0"
   }
 }

--- a/packages/api/index.test.ts
+++ b/packages/api/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import handler from './index';
+
+describe('api handler', () => {
+  it('should be a function', () => {
+    expect(typeof handler).toBe('function');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- add eslint and vitest config
- provide basic API test
- expose `lint` and `test` scripts

## Testing
- `pnpm lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `pnpm test` *(fails: vitest not found)*